### PR TITLE
fix: non-standard use of PrioritySemaphore.acquire

### DIFF
--- a/a_sync/primitives/locks/prio_semaphore.py
+++ b/a_sync/primitives/locks/prio_semaphore.py
@@ -52,6 +52,9 @@ class _AbstractPrioritySemaphore(Semaphore, Generic[PT, CM]):
     async def __aexit__(self, *_) -> None:
         self[self._top_priority].release()
     
+    async def acquire(self) -> Literal[True]:
+        return await self[self._top_priority].acquire()
+    
     def __getitem__(self, priority: Optional[PT]) -> "_AbstractPrioritySemaphoreContextManager[PT]":
         priority = self._top_priority if priority is None else priority
         if priority not in self._context_managers:


### PR DESCRIPTION
if a user used a priority semaphore's acquire method rather than the typical `async with semaphore[priority]`, it would fail