### PR TITLE
fix: re-raise RecursionError

### DIFF
--- a/a_sync/_helpers.py
+++ b/a_sync/_helpers.py
@@ -45,7 +45,7 @@ def _await(awaitable: Awaitable[T]) -> T:
     except RuntimeError as e:
         if str(e) == "This event loop is already running":
             raise SyncModeInAsyncContextError from e
-        raise ASyncRuntimeError(e) from e
+        raise e
 
 def _asyncify(func: SyncFn[P, T], executor: Executor) -> CoroFn[P, T]:  # type: ignore [misc]
     @functools.wraps(func)


### PR DESCRIPTION
RuntimeErrors were caught and wrapped into ASyncRuntimeErrors

This was done without realizing that RecursionErrors and some other types are also subclasses of RuntimeError.

We no longer do this unless the error is specifically "the event loop is already running" so you can get the correct exception as intended