### PR TITLE
fix: ASyncGenericSingleton when flag defined on class def

### DIFF
--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -1,0 +1,20 @@
+
+from a_sync.singleton import ASyncGenericSingleton
+
+def test_flag_predefined():
+    """We had a failure case where the subclass implementation assigned the flag value to the class and did not allow user to determine at init time"""
+    class Test(ASyncGenericSingleton):
+        sync=True
+        def __init__(self):
+            ...
+    Test()
+    class TestInherit(Test):
+        ...
+    TestInherit()
+
+    class Test(ASyncGenericSingleton):
+        sync=False
+    Test()
+    class TestInherit(Test):
+        ...
+    TestInherit()


### PR DESCRIPTION
There was an issue where, if a flag was defined on a subclass def and not in the __init__ method, the flag would not be found. This fixes that and ASyncSingletons will work fine regardless of how the flag is defined.