### PR TITLE
fix: iterator `__init_subclass__` when generic has no name

### DIFF
--- a/a_sync/iter.pyx
+++ b/a_sync/iter.pyx
@@ -140,7 +140,6 @@ class _AwaitableAsyncIterableMixin(AsyncIterable[T]):
                     type_string = str(type_argument)
 
         # modify the class docstring
-        example_text = type_argument._name if isinstance(type_argument, _GenericAlias) else name
         cdef str new_chunk = (
             "When awaited, a list of all {} will be returned.\n".format(type_string) +
             "\n"
@@ -149,9 +148,19 @@ class _AwaitableAsyncIterableMixin(AsyncIterable[T]):
             "    >>> all_contents = await my_object\n"
             "    >>> isinstance(all_contents, list)\n"
             "    True\n"
-            "    >>> isinstance(all_contents[0], {})\n".format(example_text) +
-            "    True\n"
         )
+
+        cdef str example_text = (
+            type_argument._name 
+            if isinstance(type_argument, _GenericAlias) 
+            else getattr(type_argument, "__name__", "")
+        )
+        
+        if example_text:
+            new_chunk += (
+                "    >>> isinstance(all_contents[0], {})\n".format(example_text) +
+                "    True\n"
+            )
 
         if cls.__doc__ is None:
             cls.__doc__ = new_chunk

--- a/tests/test_iter.py
+++ b/tests/test_iter.py
@@ -1,6 +1,6 @@
 import pytest
 import re
-from typing import AsyncIterator, Iterator, TypeVar
+from typing import AsyncIterator, Iterator, Tuple, TypeVar
 
 from a_sync import ASyncIterable, ASyncIterator
 from a_sync.exceptions import SyncModeInAsyncContextError
@@ -430,3 +430,7 @@ def test_init_subclass_with_typevar(cls_to_test):
     _T = TypeVar("_T")
 
     class MySubclass(cls_to_test[_T]): ...
+
+@test_both
+def test_init_subclass_with_generic_alias(cls_to_test):
+    class MySubclass(cls_to_test[Tuple[int, str, bool]]): ...

--- a/tests/test_iter.py
+++ b/tests/test_iter.py
@@ -431,6 +431,7 @@ def test_init_subclass_with_typevar(cls_to_test):
 
     class MySubclass(cls_to_test[_T]): ...
 
+
 @test_both
 def test_init_subclass_with_generic_alias(cls_to_test):
     class MySubclass(cls_to_test[Tuple[int, str, bool]]): ...


### PR DESCRIPTION
Adds a new test case for the failure case