### PR TITLE
chore: remove cython from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 aiolimiter==1.0.0
 async_lru_threadsafe==2.0.4
 async_property==0.2.1
-Cython>=3.0.11
-typed_envs>=0.0.2
+typed_envs>=0.0.5
 typing_extensions>=4.1.0  # typing_extensions.Unpack was introduced in 4.1.0


### PR DESCRIPTION
This is fine since pyproject.yaml specifies it as a build dependency