### PR TITLE
fix: PY_VERSION_HEX comparison

### DIFF
--- a/a_sync/_smart.pyx
+++ b/a_sync/_smart.pyx
@@ -518,6 +518,7 @@ class SmartTask(Task, Generic[T]):
         This should only be called once when handling a cancellation since
         it erases the saved context exception value.
         """
+        # if python version < 3.9
         if PY_VERSION_HEX < 0x03090000 or self._cancel_message is None:
             exc = CancelledError()
         else:

--- a/a_sync/_smart.pyx
+++ b/a_sync/_smart.pyx
@@ -518,7 +518,7 @@ class SmartTask(Task, Generic[T]):
         This should only be called once when handling a cancellation since
         it erases the saved context exception value.
         """
-        if PY_VERSION_HEX < "0x03090000" or self._cancel_message is None:
+        if PY_VERSION_HEX < 0x03090000 or self._cancel_message is None:
             exc = CancelledError()
         else:
             exc = CancelledError(self._cancel_message)


### PR DESCRIPTION
'<' not supported between instances of 'int' and 'str'