### PR TITLE
feat(cicd): use separate runners to build 32-bit and 64-bit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,70 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          # ----------------------------------------------------
+          # manylinux 64-bit
+          # ----------------------------------------------------
+          - os: ubuntu-latest
+            build_type: manylinux-x64
+            cibw_build: "cp3?-*manylinux*"
+            cibw_archs_linux: x86_64
+            artifact_name: "wheels-ubuntu-latest-manylinux-x64"
+
+          # ----------------------------------------------------
+          # manylinux 32-bit
+          # ----------------------------------------------------
+          - os: ubuntu-latest
+            build_type: manylinux-x86
+            cibw_build: "cp3?-*manylinux*"
+            cibw_archs_linux: i686
+            artifact_name: "wheels-ubuntu-latest-manylinux-x86"
+
+          # ----------------------------------------------------
+          # musllinux 64-bit
+          # ----------------------------------------------------
+          - os: ubuntu-latest
+            build_type: musllinux-x64
+            cibw_build: "cp3?-*musllinux*"
+            cibw_archs_linux: x86_64
+            artifact_name: "wheels-ubuntu-latest-musllinux-x64"
+
+          # ----------------------------------------------------
+          # musllinux 32-bit
+          # ----------------------------------------------------
+          - os: ubuntu-latest
+            build_type: musllinux-x86
+            cibw_build: "cp3?-*musllinux*"
+            cibw_archs_linux: i686
+            artifact_name: "wheels-ubuntu-latest-musllinux-x86"
+
+          # ----------------------------------------------------
+          # macOS
+          # ----------------------------------------------------
+          - os: macos-latest
+            build_type: macos
+            # For macOS, we typically don't override CIBW_BUILD or ARCHS
+            cibw_build: ""
+            cibw_archs_linux: ""
+            artifact_name: "wheels-macos-latest"
+
+          # ----------------------------------------------------
+          # Windows 64-bit
+          # ----------------------------------------------------
+          - os: windows-latest
+            build_type: winx64
+            cibw_build: ""
+            cibw_archs_windows: x86_64
+            artifact_name: "wheels-windows-latest-x64"
+
+          # ----------------------------------------------------
+          # Windows 32-bit
+          # ----------------------------------------------------
+          - os: windows-latest
+            build_type: winx86
+            cibw_build: ""
+            cibw_archs_windows: x86
+            artifact_name: "wheels-windows-latest-x86"
 
     steps:
       - name: Check out code
@@ -21,12 +84,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      # On Windows and macOS, actions/setup-python provides Python.
-      # On Ubuntu, cibuildwheel uses Docker to create manylinux wheels by default.
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+          # For Windows runners, specify architecture
+          architecture: ${{ matrix.cibw_archs_windows || '' }}
 
       - name: Install cibuildwheel
         run: |
@@ -34,15 +97,21 @@ jobs:
 
       - name: Build wheels
         env:
-          # skip building wheels for PyPy
+          # Skip PyPy
           CIBW_SKIP: pp*
+          # On Linux: manylinux / musllinux arches
+          CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux || '' }}
+          # On Windows: x64 / x86
+          CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_archs_windows || '' }}
+          # Which wheels to build for Linux (manylinux vs. musllinux)
+          CIBW_BUILD: ${{ matrix.cibw_build || '' }}
         run: |
           python -m cibuildwheel --output-dir wheelhouse
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
+          name: ${{ matrix.artifact_name }}
           path: wheelhouse/*.whl
 
   publish_sdist_and_wheels:
@@ -54,7 +123,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -64,29 +133,59 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel twine cython
-  
+
       - name: Build sdist
         run: |
           python setup.py sdist
 
-      - name: Download wheel artifacts (Ubuntu)
+      # ----------------------------------------------------
+      # Download wheels built on each runner
+      # ----------------------------------------------------
+      - name: Download manylinux 64-bit wheels
         uses: actions/download-artifact@v4
         with:
-          name: "wheels-ubuntu-latest"
-          path: wheelhouse/ubuntu
+          name: "wheels-ubuntu-latest-manylinux-x64"
+          path: wheelhouse/linux-many-x64
 
-      - name: Download wheel artifacts (macOS)
+      - name: Download manylinux 32-bit wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: "wheels-ubuntu-latest-manylinux-x86"
+          path: wheelhouse/linux-many-x86
+
+      - name: Download musllinux 64-bit wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: "wheels-ubuntu-latest-musllinux-x64"
+          path: wheelhouse/linux-musl-x64
+
+      - name: Download musllinux 32-bit wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: "wheels-ubuntu-latest-musllinux-x86"
+          path: wheelhouse/linux-musl-x86
+
+      - name: Download macOS wheels
         uses: actions/download-artifact@v4
         with:
           name: "wheels-macos-latest"
           path: wheelhouse/macos
 
-      - name: Download wheel artifacts (Windows)
+      - name: Download Windows 64-bit wheels
         uses: actions/download-artifact@v4
         with:
-          name: "wheels-windows-latest"
-          path: wheelhouse/windows
+          name: "wheels-windows-latest-x64"
+          path: wheelhouse/windows-x64
 
+      - name: Download Windows 32-bit wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: "wheels-windows-latest-x86"
+          path: wheelhouse/windows-x86
+
+      # ----------------------------------------------------
+      # Publish all built artifacts to PyPI
+      # ----------------------------------------------------
       - name: Publish sdist and wheels to PyPI
         env:
           TWINE_USERNAME: __token__
@@ -94,6 +193,10 @@ jobs:
         run: |
           twine upload \
             dist/* \
-            wheelhouse/ubuntu/*.whl \
+            wheelhouse/linux-many-x64/*.whl \
+            wheelhouse/linux-many-x86/*.whl \
+            wheelhouse/linux-musl-x64/*.whl \
+            wheelhouse/linux-musl-x86/*.whl \
             wheelhouse/macos/*.whl \
-            wheelhouse/windows/*.whl
+            wheelhouse/windows-x64/*.whl \
+            wheelhouse/windows-x86/*.whl


### PR DESCRIPTION
This will let us make releases in 10 minutes instead of an hour