### PR TITLE
fix: (partially) handle cancellation in ProcessingQueue classes

### DIFF
--- a/a_sync/primitives/queue.py
+++ b/a_sync/primitives/queue.py
@@ -978,7 +978,7 @@ class SmartProcessingQueue(_VariablePriorityQueueMixin[T], ProcessingQueue[Conca
                     continue
 
                 log("processing %s", fut)
-                
+
                 # TODO: implement some callback to handle cancellation
 
                 try:


### PR DESCRIPTION
This will not propagate the cancellation if the job is actively running, but it will prevent a still-queued job from starting if the originating task has been cancelled

Full implementation will come later