### PR TITLE
fix(test): broken import in utils iterator test

### DIFF
--- a/tests/utils/test_iterators.py
+++ b/tests/utils/test_iterators.py
@@ -1,7 +1,8 @@
-# mypy: disable-error-code=no-untyped-def
 import asyncio
 from collections.abc import AsyncIterator, Callable, Iterable
-from typing import Any, Generic, TypeVar, cast, override
+from typing import Any, Generic, TypeVar, cast
+
+from typing_extensions import override
 
 import pytest
 

--- a/tests/utils/test_repr.py
+++ b/tests/utils/test_repr.py
@@ -1,4 +1,3 @@
-# mypy: disable-error-code=no-untyped-def
 from a_sync.utils.repr import repr_trunc
 
 


### PR DESCRIPTION
## Summary
- use `typing_extensions.override` in the iterators test helper to satisfy mypy

## Testing
- mypy --config-file pyproject.toml tests/utils/test_iterators.py