### PR TITLE
test(mypy): annotate iter tests

### DIFF
--- a/tests/iter/test_asyncgenfunc.py
+++ b/tests/iter/test_asyncgenfunc.py
@@ -1,12 +1,13 @@
 from asyncio import TimerHandle
+from collections.abc import AsyncIterator
 
 import pytest
 
 from a_sync.iter import ASyncGeneratorFunction, ASyncIterator
 
 
-def test_a_sync_generator_function_init():
-    async def test():
+def test_a_sync_generator_function_init() -> None:
+    async def test() -> AsyncIterator[int]:
         yield 1
         yield 2
 
@@ -18,9 +19,9 @@ def test_a_sync_generator_function_init():
     assert wrapped._cache_handle is None
 
 
-def test_a_sync_generator_function_decorate_func():
+def test_a_sync_generator_function_decorate_func() -> None:
     @ASyncGeneratorFunction
-    async def test():
+    async def test() -> AsyncIterator[int]:
         yield 1
         yield 2
 
@@ -30,10 +31,10 @@ def test_a_sync_generator_function_decorate_func():
     assert test._cache_handle is None
 
 
-def test_a_sync_generator_function_decorate_method():
+def test_a_sync_generator_function_decorate_method() -> None:
     class MyClass:
         @ASyncGeneratorFunction
-        async def test(self):
+        async def test(self) -> AsyncIterator[int]:
             yield 1
             yield 2
 
@@ -51,9 +52,9 @@ def test_a_sync_generator_function_decorate_method():
     assert isinstance(instance.test._cache_handle, TimerHandle)
 
 
-def test_a_sync_generator_function_call_iter():
+def test_a_sync_generator_function_call_iter() -> None:
     @ASyncGeneratorFunction
-    async def test():
+    async def test() -> AsyncIterator[int]:
         yield 1
         yield 2
 
@@ -62,23 +63,23 @@ def test_a_sync_generator_function_call_iter():
     assert list(retval) == [1, 2]
 
 
-def test_a_sync_generator_method_call_iter():
+def test_a_sync_generator_method_call_iter() -> None:
     class MyClass:
         @ASyncGeneratorFunction
-        async def test(self):
+        async def test(self) -> AsyncIterator[int]:
             yield 1
             yield 2
 
     instance = MyClass()
-    retval = instance.test()
+    retval = instance.test()  # type: ignore[call-arg]
     assert isinstance(retval, ASyncIterator)
     assert list(retval) == [1, 2]
 
 
 @pytest.mark.asyncio_cooperative
-async def test_a_sync_generator_function_call_aiter():
+async def test_a_sync_generator_function_call_aiter() -> None:
     @ASyncGeneratorFunction
-    async def test():
+    async def test() -> AsyncIterator[int]:
         yield 1
         yield 2
 
@@ -88,23 +89,23 @@ async def test_a_sync_generator_function_call_aiter():
 
 
 @pytest.mark.asyncio_cooperative
-async def test_a_sync_generator_method_call_aiter():
+async def test_a_sync_generator_method_call_aiter() -> None:
     class MyClass:
         @ASyncGeneratorFunction
-        async def test(self):
+        async def test(self) -> AsyncIterator[int]:
             yield 1
             yield 2
 
     instance = MyClass()
-    retval = instance.test()
+    retval = instance.test()  # type: ignore[call-arg]
     assert isinstance(retval, ASyncIterator)
     assert [x async for x in retval] == [1, 2]
 
 
 @pytest.mark.asyncio_cooperative
-async def test_a_sync_generator_function_call_await():
+async def test_a_sync_generator_function_call_await() -> None:
     @ASyncGeneratorFunction
-    async def test():
+    async def test() -> AsyncIterator[int]:
         yield 1
         yield 2
 
@@ -114,14 +115,14 @@ async def test_a_sync_generator_function_call_await():
 
 
 @pytest.mark.asyncio_cooperative
-async def test_a_sync_generator_method_call_await():
+async def test_a_sync_generator_method_call_await() -> None:
     class MyClass:
         @ASyncGeneratorFunction
-        async def test(self):
+        async def test(self) -> AsyncIterator[int]:
             yield 1
             yield 2
 
     instance = MyClass()
-    retval = instance.test()
+    retval = instance.test()  # type: ignore[call-arg]
     assert isinstance(retval, ASyncIterator)
     assert await retval == [1, 2]


### PR DESCRIPTION
## Summary
- add straightforward type annotations to iter tests for strict mypy
- small, targeted ignores where stubs are missing or intentionally invalid usage is asserted

## Testing
- mypy --config-file /tmp/mypy-strict2.ini tests/iter/test_iterables.py tests/iter/test_asyncgenfunc.py
