### PR TITLE
chore: ignore .gitignore and *.md in workflow paths

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,7 +7,8 @@ on:
     paths-ignore:
       - '.github/workflows/**'
       - '!.github/workflows/lint.yaml'
-
+      - '.gitignore'
+      - '*.md'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- ignore `.gitignore` and `*.md` in workflow `paths-ignore`

## Rationale
- avoid running lint on doc-only or gitignore-only changes

## Details
- update `.github/workflows/lint.yaml`
- Tests: `python -m pytest` (fails: `ModuleNotFoundError: No module named 'a_sync.a_sync.base'`)