### PR TITLE
fix(mypy): fix type errors

### DIFF
--- a/a_sync/_typing.py
+++ b/a_sync/_typing.py
@@ -68,7 +68,16 @@ import asyncio
 from collections.abc import AsyncIterable, Awaitable, Callable, Coroutine, Iterable
 from concurrent.futures._base import Executor
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, Literal, Protocol, TypedDict, TypeVar, runtime_checkable
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    Protocol,
+    TypedDict,
+    TypeAlias,
+    TypeVar,
+    runtime_checkable,
+)
 
 from typing_extensions import ParamSpec
 
@@ -94,10 +103,10 @@ P = ParamSpec("P")
 Numeric = int | float | Decimal
 """Type alias for numeric values of types int, float, or Decimal."""
 
-MaybeAwaitable = Awaitable[T] | T
+MaybeAwaitable: TypeAlias = Awaitable[T] | T
 """Type alias for values that may or may not be awaitable. Useful for functions that can return either an awaitable or a direct value."""
 
-MaybeCoro = Coroutine[Any, Any, T] | T
+MaybeCoro: TypeAlias = Coroutine[Any, Any, T] | T
 "Type alias for values that may or may not be coroutine."
 
 CoroFn = Callable[P, Awaitable[T]]

--- a/a_sync/a_sync/modifiers/cache/__init__.py
+++ b/a_sync/a_sync/modifiers/cache/__init__.py
@@ -151,7 +151,7 @@ def apply_async_cache(
         raise exceptions.FunctionNotAsync(coro_fn)
 
     if cache_type == "memory":
-        cache_decorator = apply_async_memory_cache(
+        cache_decorator: AsyncDecorator[P, T] = apply_async_memory_cache(
             maxsize=ram_cache_maxsize, ttl=ram_cache_ttl, typed=cache_typed
         )
         return cache_decorator if coro_fn is None else cache_decorator(coro_fn)


### PR DESCRIPTION
## Summary
Improve typing annotations for core helpers and queue internals to reduce mypy noise.

## Rationale
Mypy flagged untyped locals and TypeVar-based aliases; annotating at use sites resolves errors without changing runtime behavior.

## Details
- Mark `MaybeAwaitable`/`MaybeCoro` as explicit `TypeAlias`.
- Annotate `cache_decorator` to satisfy var-annotated checks.
- Add queue internal annotations (deque, TYPE_CHECKING attributes, typed locals) to clarify internal state.

## Testing
- `pytest` (fails during collection: `ModuleNotFoundError: No module named 'a_sync.a_sync.base'`)