### PR TITLE
fix(utils): render CancelMessage with stored values

### DIFF
--- a/a_sync/utils/__init__.py
+++ b/a_sync/utils/__init__.py
@@ -129,4 +129,4 @@ class CancelMessage:
         return f"CancelMessage('{str(self)}')"
 
     def __str__(self) -> str:
-        return f"{message}: {result!r}"
+        return f"{self.message}: {self.result!r}"


### PR DESCRIPTION
**Summary**
- Fix `CancelMessage.__str__` to use the instance `message`/`result` fields.

**Rationale**
- Prevents a `NameError` and ensures cancel diagnostics include the actual result value.

**Details**
- Tests: `python -m pytest tests/a_sync/test_property.py` (fails: ImportError `cannot import name 'ContractName'` from `eth_typing` during pytest plugin load from `web3`).
- `pip check` (fails: `eth-brownie 1.22.0.dev2` requires `pytest==6.2.5` and `python-dotenv==0.16.0`, but `pytest 9.0.2` and `python-dotenv 1.2.1` are installed).