### PR TITLE
feat(mypy): add a_sync mypy plugin

### DIFF
--- a/a_sync_mypy_plugin/__init__.py
+++ b/a_sync_mypy_plugin/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from typing import Iterable, Optional
 
+from mypy.checkmember import analyze_member_access
 from mypy.nodes import (
     AssignmentStmt,
     CallExpr,
@@ -473,10 +474,21 @@ def _future_or_proxy_attribute_hook(
         return ctx.default_attr_type
     if proper.type.fullname != expected_fullname and not proper.type.has_base(expected_fullname):
         return ctx.default_attr_type
+    if proper.type.has_readable_member(attr_name):
+        return ctx.default_attr_type
     if not proper.args:
         return ctx.default_attr_type
     inner = proper.args[0]
-    return ctx.default_attr_type
+    return analyze_member_access(
+        attr_name,
+        inner,
+        ctx.context,
+        is_lvalue=ctx.is_lvalue,
+        is_super=False,
+        is_operator=False,
+        original_type=inner,
+        chk=ctx.api,
+    )
 
 
 def _a_sync_function_hook(ctx: FunctionContext) -> Type:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ line-length = 100
 line_length = 100
 
 [tool.mypy]
-plugins = ["a_sync.mypy_plugin"]
+plugins = ["a_sync_mypy_plugin"]
 files = ["a_sync"]
 pretty = true
 ignore_missing_imports = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 cython>=3.0.11
+mypy==1.19.1
 pytest
 pytest-asyncio-cooperative
 pytest-cov

--- a/tests/mypy/test_mypy_plugin.py
+++ b/tests/mypy/test_mypy_plugin.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+from textwrap import dedent
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_mypy(tmp_path: Path, code: str) -> str:
+    source = tmp_path / "snippet.py"
+    source.write_text(dedent(code))
+    cache_dir = tmp_path / ".mypy_cache"
+    env = dict(os.environ)
+    env["MYPY_CACHE_DIR"] = str(cache_dir)
+    result = subprocess.run(
+        [sys.executable, "-m", "mypy", str(source)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    output = (result.stdout or "") + (result.stderr or "")
+    assert "INTERNAL ERROR" not in output
+    assert "Traceback (most recent call last)" not in output
+    return output
+
+
+def _reveal_types(output: str) -> Counter[str]:
+    revealed: list[str] = []
+    for line in output.splitlines():
+        if "Revealed type is" in line:
+            revealed.append(line.split("Revealed type is", 1)[1].strip())
+    return Counter(revealed)
+
+
+def test_proxy_and_future_attribute_typing(tmp_path: Path) -> None:
+    output = _run_mypy(
+        tmp_path,
+        """
+        from a_sync.async_property.proxy import AwaitableProxy, ObjectProxy
+        from a_sync.future import ASyncFuture
+
+        class Thing:
+            def __init__(self) -> None:
+                self.count = 1
+                self.name = "hey"
+
+        thing = Thing()
+
+        obj: ObjectProxy[Thing] = ObjectProxy(thing)
+        awaitable: AwaitableProxy[Thing] = AwaitableProxy(thing)
+        future: ASyncFuture[Thing]
+
+        reveal_type(obj.count)
+        reveal_type(obj.name)
+        reveal_type(awaitable.count)
+        reveal_type(awaitable.name)
+        reveal_type(future.count)
+        reveal_type(future.name)
+        """,
+    )
+    expected = Counter(
+        [
+            '"builtins.int"',
+            '"builtins.str"',
+            '"builtins.int"',
+            '"builtins.str"',
+            '"builtins.int"',
+            '"builtins.str"',
+        ]
+    )
+    assert _reveal_types(output) == expected
+
+
+def test_property_descriptor_typing(tmp_path: Path) -> None:
+    output = _run_mypy(
+        tmp_path,
+        """
+        from a_sync.a_sync.base import ASyncGenericBase
+        from a_sync.a_sync.property import a_sync_property
+
+        class Thing(ASyncGenericBase):
+            @a_sync_property
+            def value(self) -> int:
+                return 1
+
+        reveal_type(Thing().value)
+        """,
+    )
+    expected = Counter(['"typing.Awaitable[builtins.int]"'])
+    assert _reveal_types(output) == expected


### PR DESCRIPTION
## Summary
Add an initial mypy plugin for a_sync so decorator- and descriptor-heavy APIs get better type inference.

## Rationale
a_sync’s runtime wrappers and descriptors are difficult for mypy to infer without a plugin; this establishes baseline hooks we can refine.

## Details
- Add `a_sync/mypy_plugin.py` with class, function, method, and attribute hooks for core a_sync types.
- Enable the plugin in `pyproject.toml`.
- Proxy attribute hook currently returns the default attribute type (follow-up planned).

## Testing
- `.venv/bin/python -m mypy --config-file pyproject.toml` (fails: existing errors across project; see `/tmp/mypy-plugin-pr.out`)
- `.venv/bin/python -m pytest` (fails: 437 failed, 265 passed, 1 skipped; see `/tmp/pytest-plugin-pr.out`)
- `.venv/bin/python -m black --version` (not run: module not installed in venv)
- `.venv/bin/python -m isort --version-number` (not run: module not installed in venv)
