### PR TITLE
fix(future): restore ASyncFuture __await__ iterator

### DIFF
--- a/a_sync/future.py
+++ b/a_sync/future.py
@@ -369,7 +369,10 @@ class ASyncFuture(concurrent.futures.Future, Awaitable[T]):
         """
         del _materialize(self)[key]
 
-    async def __await__(self) -> Generator[Any, None, T]:
+    def __await__(self) -> Generator[Any, None, T]:
+        return self._await().__await__()
+
+    async def _await(self) -> T:
         try:
             result = await self.__awaitable__
         except Exception as exc:


### PR DESCRIPTION
## Summary
Restore `ASyncFuture.__await__` to return an iterator so it complies with the await protocol and avoids coroutine-return `TypeError` (e.g., eth-portfolio collateral paths).

## Changes
- Move await logic into `_await` and have `__await__` return its iterator.

## Testing
- `python setup.py build_ext --inplace`
- `pytest tests/test_future.py tests/asyncio/test_create_task.py` (fails in this env: missing default event loop in main thread; `test_create_task_skip_gc_until_done` persisted task pruning assertion)
