### PR TITLE
fix(tests): suppress sync-in-async runtime warning noise in async test overrides

### DIFF
--- a/tests/a_sync/test_base.py
+++ b/tests/a_sync/test_base.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+import warnings
 
 import pytest
 
@@ -146,10 +147,16 @@ async def test_method_async(cls: type, i: int):
 
         # Can we override with kwargs?
         # Does it fail if we run it synchronously with the event loop running?
-        with pytest.raises(SyncModeInAsyncContextError):
-            async_instance.test_fn(sync=True)
-        with pytest.raises(SyncModeInAsyncContextError):
-            async_instance.test_fn(asynchronous=False)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=RuntimeWarning,
+                message=r"coroutine '.*' was never awaited",
+            )
+            with pytest.raises(SyncModeInAsyncContextError):
+                async_instance.test_fn(sync=True)
+            with pytest.raises(SyncModeInAsyncContextError):
+                async_instance.test_fn(asynchronous=False)
 
 
 @classes
@@ -200,8 +207,14 @@ async def test_property_async(cls: type, i: int):
     getter_coro = getter()
     assert asyncio.iscoroutine(getter_coro), getter_coro
     assert await getter_coro == i * 2
-    with pytest.raises(SyncModeInAsyncContextError):
-        await getter(sync=True)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=RuntimeWarning,
+            message=r"coroutine '.*' was never awaited",
+        )
+        with pytest.raises(SyncModeInAsyncContextError):
+            await getter(sync=True)
 
 
 @classes
@@ -274,8 +287,14 @@ async def test_cached_property_async(cls: type, i: int):
     assert await getter_coro == i * 3
 
     # Can we override them too?
-    with pytest.raises(SyncModeInAsyncContextError):
-        getter(sync=True)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=RuntimeWarning,
+            message=r"coroutine '.*' was never awaited",
+        )
+        with pytest.raises(SyncModeInAsyncContextError):
+            getter(sync=True)
     assert await async_instance.__test_cached_property__(sync=False) == i * 3
 
     # Did it only run once?

--- a/tests/a_sync/test_meta.py
+++ b/tests/a_sync/test_meta.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+import warnings
 
 import pytest
 
@@ -75,15 +76,27 @@ async def test_singleton_meta_async(cls: type, i: int):
     ), "There is a 2 second sleep in 'test_cached_property' but it should only run once."
 
     # Can we override with kwargs?
-    with pytest.raises(RuntimeError):
-        async_instance.test_fn(sync=True)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=RuntimeWarning,
+            message=r"coroutine '.*' was never awaited",
+        )
+        with pytest.raises(RuntimeError):
+            async_instance.test_fn(sync=True)
 
     # Can we access hidden methods for properties?
     assert await async_instance.__test_property__() == 0
     assert await async_instance.__test_cached_property__() == 0
     # Can we override them too?
-    with pytest.raises(RuntimeError):
-        async_instance.__test_cached_property__(sync=True)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=RuntimeWarning,
+            message=r"coroutine '.*' was never awaited",
+        )
+        with pytest.raises(RuntimeError):
+            async_instance.__test_cached_property__(sync=True)
 
 
 class TestUnspecified(ASyncGenericSingleton):


### PR DESCRIPTION
## Summary
- suppress expected `RuntimeWarning: coroutine ... was never awaited` emissions in async tests that intentionally assert sync-in-async override failures
- update warning handling in `tests/a_sync/test_meta.py` and `tests/a_sync/test_base.py` only

## Rationale
- CI logs still contained repeated runtime warnings at:
  - `tests/a_sync/test_meta.py:78`
  - `tests/a_sync/test_meta.py:85`
  - `tests/a_sync/test_base.py:277`
  - and related sync-override assertion paths in `tests/a_sync/test_base.py`
- these are expected failure-path assertions, but the warning noise obscures actionable CI output

## Details
- added scoped `warnings.catch_warnings()` blocks around sync-in-async override assertions
- filtered only `RuntimeWarning` messages matching `coroutine '.*' was never awaited`
- kept original exception assertions and test intent unchanged
- no runtime/library code changes; tests-only patch

## Testing
- `.venv/bin/python -m pip check`
- `.venv/bin/pytest -q tests/a_sync/test_meta.py -k test_singleton_meta_async`
- `.venv/bin/pytest -q tests/a_sync/test_base.py -k "test_method_async or test_property_async or test_cached_property_async"`
- `.venv/bin/pytest -q tests/a_sync/test_meta.py tests/a_sync/test_base.py`